### PR TITLE
Add general dimensional tensor derivative

### DIFF
--- a/Theory/TensorDifferentiation.md
+++ b/Theory/TensorDifferentiation.md
@@ -15,7 +15,7 @@ Here, constant implies that the base vectors are constant in space.
 Hence, it suffices to differentiate the coefficients as the derivative of each base vector is zero. 
 In general, for an $N$th order $\boldsymbol{y} = y_{i_1 i_2 \cdots i_N}\onebase{i_1}\otimes\onebase{i_2}\otimes\cdots\otimes\onebase{i_N}$ and an $M$th order $\boldsymbol{x} = x_{j_1 j_2 \cdots j_M}\onebase{j_1}\otimes\onebase{j_2}\otimes\cdots\otimes\onebase{j_M}$, we have that
 \begin{align}
-\pdiff{\boldsymbol{y}}{\boldsymbol{x}} &= \left[\pdiff{y_{i_1 i_2 \cdots i_N}}{x_{j_1 j_2 \cdots j_M}}\right] \onebase{i_1}\otimes\onebase{i_2}\otimes\otimes\onebase{i_N}\otimes\onebase{j_1}\otimes\onebase{j_2}\otimes\cdots\otimes\onebase{j_M}
+\pdiff{\boldsymbol{y}}{\boldsymbol{x}} &= \left[\pdiff{y_{i_1 i_2 \cdots i_N}}{x_{j_1 j_2 \cdots j_M}}\right] \onebase{i_1}\otimes\onebase{i_2}\otimes\cdots\otimes\onebase{i_N}\otimes\onebase{j_1}\otimes\onebase{j_2}\otimes\cdots\otimes\onebase{j_M}
 \end{align}
 
 \collaps{Furthermore, since we can consider each free coefficient, e.g., $u_1$, as a scalar value, we can apply basic calculus rules, such as the chain and product rules. Even when considering dummy (summation) indices, these rules hold (expand to see an example).}{Consider the following in 2d: 

--- a/Theory/TensorDifferentiation.md
+++ b/Theory/TensorDifferentiation.md
@@ -11,7 +11,12 @@ that is, differentiation a tensor valued expression wrt. to a tensor. In this ca
 \begin{align}
 \pdiff{\tv{u}}{\tv{v}} = \pdiff{u_i}{v_j} \baseij
 \end{align}
-Here, constant implies that the base vectors are constant in space. Hence, it suffices to differentiate the coefficients as the derivative of each base vector is zero. 
+Here, constant implies that the base vectors are constant in space. 
+Hence, it suffices to differentiate the coefficients as the derivative of each base vector is zero. 
+In general, for an $N$th order $\boldsymbol{y} = y_{i_1 i_2 \cdots i_N}\onebase{i_1}\otimes\onebase{i_2}\otimes\cdots\otimes\onebase{i_N}$ and an $M$th order $\boldsymbol{x} = x_{j_1 j_2 \cdots j_M}\onebase{j_1}\otimes\onebase{j_2}\otimes\cdots\otimes\onebase{j_M}$, we have that
+\begin{align}
+\pdiff{\boldsymbol{y}}{\boldsymbol{x}} &= \left[\pdiff{y_{i_1 i_2 \cdots i_N}}{x_{j_1 j_2 \cdots j_M}}\right] \onebase{i_1}\otimes\onebase{i_2}\otimes\otimes\onebase{i_N}\otimes\onebase{j_1}\otimes\onebase{j_2}\otimes\cdots\otimes\onebase{j_M}
+\end{align}
 
 \collaps{Furthermore, since we can consider each free coefficient, e.g., $u_1$, as a scalar value, we can apply basic calculus rules, such as the chain and product rules. Even when considering dummy (summation) indices, these rules hold (expand to see an example).}{Consider the following in 2d: 
 The tensor $\ts{b}$ is a function of the tensor $\ts{a}$, such that $\ts{b}(\ts{a}) = \ts{a}\ts{a}$ (i.e. $b_{ij} = a_{in}a_{nj}$). We would like to differentiate $\ts{a}\ts{b}$ wrt. $\ts{a}$. 


### PR DESCRIPTION
Add general case for cartesian coordinate system, ref #31 

![image](https://github.com/user-attachments/assets/11a13038-49f5-4def-9750-772b118adae3)

Adding for general coordinates is a much larger project, as this requires introducing this properly from the beginning. Therefore, I would defer that update to when I have time. 

However, if someone would like to work on that, I think the cleanest option would be to add an "advanced" page that considers tensors in general coordinate systems, explaining this using the "standard" cases introduced already as a starting point. 